### PR TITLE
Fix solutions seperators, unbreak everything else

### DIFF
--- a/src/Components/Editor.js
+++ b/src/Components/Editor.js
@@ -61,6 +61,8 @@ class Editor extends Component {
       if (Array.isArray(data[1])) {
         if (data[0] === 'tests') {
           data[1] = data[1].join('EOL\n');
+        } else if(data[0] === 'solutions') {
+          data[1] = data[1].join('\nEOS\n');
         } else {
           data[1] = data[1].join('\n');
         }

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -16,15 +16,11 @@ function parser(key) {
     case 'tail':
     case 'challengeSeed':
     case 'MDNlinks':
+      return function(val) { return val.split('\n'); };
     case 'solutions':
-      // NOTE:  This only works for one solution
-      return function(val) {
-        return(val.split('EOS\n')
-          .filter(function(val){
-            return(val.replace(/\s/gi).length > 0)
-          }));};
+      return function(val) { return val.split(/\s*EOS\s*/); };
     case 'tests':
-      return function(val) { return val.split('EOL\n'); };
+      return function(val) { return val.split(/\s*EOL\s*/); };
     default:
       return function(val) { return val; };
   }
@@ -54,13 +50,7 @@ export default function(prevState = initialState, action) {
       return (Object.assign({}, prevState, action.payload));
 
     case 'loadChallenge':
-      let cData = Object.assign({}, prevState, action.payload);
-      let sData = [""];
-      cData.activeChallenge.solutions.map(function(sol){
-        sData[0] = sData[0] + sol + "EOS\n";
-      });
-      cData.activeChallenge.solutions = sData;
-      return (cData);
+      return (Object.assign({}, prevState, action.payload));
 
     case 'loadFile':
       return (Object.assign({}, prevState, action.payload));


### PR DESCRIPTION
The multi-solution "fix" had two unfortunate side effects:
1. It utterly broke anything else that was an array of strings - they would no longer be broken up by their `\n`, as required by all prior cases.
2. Every time you loaded/saved, you'd get an extra solution line.

I changed the code to work more like the `EOL` solution.
